### PR TITLE
リレーション、アバター

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -51,6 +51,7 @@ class RegisterController extends Controller
         return Validator::make($data, [
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
+            'avatar' => ['image'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
         ]);
     }
@@ -63,9 +64,20 @@ class RegisterController extends Controller
      */
     protected function create(array $data)
     {
+
+        if (isset($data['avatar'])) {
+            $avatarName = $data['avatar']->getClientOriginalName();
+            $data['avatar']->move(public_path('storage/images'), $avatarName);
+            // $image->move(public_path('storage/images'), $imageName);
+        } else {
+            $avatarName = null; // アバターがアップロードされていない場合はnullをセット
+        }
+    
+        // ユーザーの作成
         return User::create([
             'name' => $data['name'],
             'email' => $data['email'],
+            'avatar' => $avatarName,
             'password' => Hash::make($data['password']),
         ]);
     }

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -15,6 +15,7 @@ class PostController extends Controller
         function index()
         {
             $posts = Post::all();
+            $posts = Post::orderByDesc('created_at')->get();
         return view('posts.index', compact('posts'));
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -19,6 +19,7 @@ class User extends Authenticatable
      */
     protected $fillable = [
         'name',
+        'avatar',
         'email',
         'password',
     ];

--- a/database/migrations/2024_04_01_034224_add_column_avatar_to_user_table.php
+++ b/database/migrations/2024_04_01_034224_add_column_avatar_to_user_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            //$table変数を
+            $table->string('avatar')->after('name') ;
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('avatar');
+        });
+    }
+};

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -86,7 +86,7 @@
                 <div class="card-header">{{ __('Register') }}</div>
 
                 <div class="card-body">
-                    <form method="POST" action="{{ route('register') }}">
+                    <form method="POST" action="{{ route('register') }}" enctype="multipart/form-data" >
                         @csrf
 
                         <div class="row mb-3">
@@ -136,6 +136,19 @@
 
                             <div class="col-md-6">
                                 <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
+                            </div>
+                        </div>
+
+                        <div class="form-group row">
+                            <label for="avatar" class="col-md-4 col-form-label text-md-right">{{ __('プロフィール画像 (サイズは1024Kbyteまで）') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="avatar" type="file" name="avatar" class="@error('avatar') is-invalid @enderror">
+                                @error('avatar')
+                                    <span class="invalid-feedback" role="alert">
+                                        <strong>{{ $message }}</strong>
+                                    </span>
+                                @enderror
                             </div>
                         </div>
 

--- a/resources/views/layouts/app_original.blade.php
+++ b/resources/views/layouts/app_original.blade.php
@@ -21,13 +21,9 @@
 <body>
   <header>
 
-    {{-- <div class="header-righr"> --}}
-      {{-- <h4>user name</h4> --}}
-      {{-- <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2A10.13 10.13 0 0 0 2 12a10 10 0 0 0 4 7.92V20h.1a9.7 9.7 0 0 0 11.8 0h.1v-.08A10 10 0 0 0 22 12 10.13 10.13 0 0 0 12 2zM8.07 18.93A3 3 0 0 1 11 16.57h2a3 3 0 0 1 2.93 2.36 7.75 7.75 0 0 1-7.86 0zm9.54-1.29A5 5 0 0 0 13 14.57h-2a5 5 0 0 0-4.61 3.07A8 8 0 0 1 4 12a8.1 8.1 0 0 1 8-8 8.1 8.1 0 0 1 8 8 8 8 0 0 1-2.39 5.64z"/><path d="M12 6a3.91 3.91 0 0 0-4 4 3.91 3.91 0 0 0 4 4 3.91 3.91 0 0 0 4-4 3.91 3.91 0 0 0-4-4zm0 6a1.91 1.91 0 0 1-2-2 1.91 1.91 0 0 1 2-2 1.91 1.91 0 0 1 2 2 1.91 1.91 0 0 1-2 2z"/></svg> --}}
-
+ 
     </div>
     <div class="header-left">
-            {{-- <img class="logo" src="{{ asset('img/logo.png') }}" alt=""> --}}
         </div>
         <div class="header-right">
         <div class="dropdown nav">
@@ -43,14 +39,16 @@
             <li><a class="dropdown-item" href="{{ route('register') }}" onclick="event.preventDefault();
                                                      document.getElementById('logout-form').submit();">{{ __('Register') }}</a></li>
           </ul>
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M12 2A10.13 10.13 0 0 0 2 12a10 10 0 0 0 4 7.92V20h.1a9.7 9.7 0 0 0 11.8 0h.1v-.08A10 10 0 0 0 22 12 10.13 10.13 0 0 0 12 2zM8.07 18.93A3 3 0 0 1 11 16.57h2a3 3 0 0 1 2.93 2.36 7.75 7.75 0 0 1-7.86 0zm9.54-1.29A5 5 0 0 0 13 14.57h-2a5 5 0 0 0-4.61 3.07A8 8 0 0 1 4 12a8.1 8.1 0 0 1 8-8 8.1 8.1 0 0 1 8 8 8 8 0 0 1-2.39 5.64z"/><path d="M12 6a3.91 3.91 0 0 0-4 4 3.91 3.91 0 0 0 4 4 3.91 3.91 0 0 0 4-4 3.91 3.91 0 0 0-4-4zm0 6a1.91 1.91 0 0 1-2-2 1.91 1.91 0 0 1 2-2 1.91 1.91 0 0 1 2 2 1.91 1.91 0 0 1-2 2z"/></svg>
+
+          <img src="{{asset('storage/images/'.Auth::User()->avatar)}}" class="d-block rounded-circle mb-3">
+          
         </div>
         </div>
   </header>
   @yield('content')
   <footer>
     <div class="footer-container">
-      <a href=""><i class="ri-add-box-line"></i></a>
+      <a href="{{ route('posts.index') }}"><i class="ri-add-box-line"></i></a>
      <a href="{{ route('home') }}"><i class="ri-file-list-line"></i></a>
       <a href=""><i class="ri-play-list-add-line"></i></a>
     </div>

--- a/resources/views/posts/show.blade.php
+++ b/resources/views/posts/show.blade.php
@@ -7,7 +7,7 @@
               <div class="card mt-3">
 
                    @if($post->image)
-                   <img src="{{ asset('storage/' . $post->image) }}" alt="Post Image">
+                   <img src="{{ asset('storage/images/' . $post->image) }}" alt="Post Image">
                      @else
                          <p>No image available</p>
                      @endif


### PR DESCRIPTION
- リレーション
　コメントが付いたまま投稿を削除
　問題-> コメントが付いたまま投稿を削除できなかった
　原因-> コメントの外部制約キーがpost（１対多の1の方）が削除された時に悪さをしていたから
　解決策->('cascade')をcommentsのmigrationファイルのuser_idに入れることで解消
- avator
　継承で使用するアバター機能の追加。
　今後の留意点：保存するときのパスの記述方法とやっぱりimageの容量の問題がある。
　未解決：imageの容量の制限
